### PR TITLE
Vegeta re-vamp based on revised test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ oc create secret generic kubeconfig-secret --from-file=kubeconfig=<YOUR-KUBECONF
 * `OLS_TEST_HOST` - String indicating OLS endpoint to perform load testing.
 * `OLS_TEST_UUID`(Optional) - String specifying an unique ID. Will be helpful while comparing two runs or while looking at a specific run results.
 * `OLS_TEST_AUTH_TOKEN` - OLS auth token string.
-* `OLS_TEST_HIT_SIZE` - Indicates the total amount of requests to be sent as a part of the load testing.
-* `OLS_TEST_RPS` - Requests per second to be sent to the OLS endpoint in parallel.
+* `OLS_TEST_DURATION` - Load testing duration on each API endpoint.
+* `OLS_TEST_WORKERS` - Amount of parallel workers to trigger load on OLS. This will basically help us send requests in parallel.
 * `OLS_TEST_METRIC_STEP` - Step size for the cluster prometheus metrics to be captured.
 * `OLS_TEST_PROFILES` - List of metric profiles that contain queries to be executed on prometheus.
 * `OLS_TEST_ES_HOST`(Optional) - Elastic search host url. If not specified metrics will be indexed locally.
@@ -81,8 +81,8 @@ OPTIONS:
    --host value        --host localhost:6060 (default: "http://localhost:6060") [$OLS_TEST_HOST]
    --authtoken value   --authtoken authtoken [$OLS_TEST_AUTH_TOKEN]
    --uuid value        --uuid f519d9b2-aa62-44ab-9ce8-4156b712f6d2 (default: "08fd0205-d2d8-4954-b83e-86226dd4e2ac") [$OLS_TEST_UUID]
-   --hitsize value     --hitsize 100 (default: 25) [$OLS_TEST_HIT_SIZE]
-   --rps value         --rps 50 (default: 10) [$OLS_TEST_RPS]
+   --duration value    --duration 1m (default: 1m0s) [$OLS_TEST_DURATION]
+   --workers value     --workers 10 (default: 10) [$OLS_TEST_WORKERS]
    --eshost value      --eshost eshosturl [$OLS_TEST_ES_HOST]
    --esindex value     --esindex esindex [$OLS_TEST_ES_INDEX]
    --metricstep value  --metricstep 30 (default: 30) [$OLS_TEST_METRIC_STEP]
@@ -92,7 +92,7 @@ OPTIONS:
 #### Example Usage
 ```
 export KUBECONFIG=<your-kubeconfig-path>
-ols-load-generator attack --host https://127.0.0.1:9001 --uuid random-uuid --authtoken 'auth-token' --hitsize 5 --rps 1
+ols-load-generator attack --host https://127.0.0.1:9001 --uuid random-uuid --authtoken 'auth-token' --duration 1m --workers 10
 ```
 ### index sub-command
 Subcommand to scrape and index cluster prometheus metrics within a given time range. 

--- a/attacker/apis.go
+++ b/attacker/apis.go
@@ -48,8 +48,9 @@ func getRequestCommons(ctx context.Context, endpoint, host, token string) (strin
 }
 
 // CreateQueryRequests returns the list of requests to perform POST operation on query endpoint.
-func CreateQueryRequests(ctx context.Context, hitSize int, host, token string, withCache bool) []map[string]interface{} {
+func CreateQueryRequests(ctx context.Context, duration time.Duration, workers int, host, token string, withCache bool) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/v1/query", host, token)
+	hitSize := int(duration.Seconds()) * workers
 	var requests []map[string]interface{}
 
 	data, err := assets.ReadFile("assets/questions.yaml")
@@ -71,9 +72,9 @@ func CreateQueryRequests(ctx context.Context, hitSize int, host, token string, w
 	body := make(map[string]string)
 	if withCache {
 		body["conversation_id"] = "00000000-0000-0000-0000-000000000000"
-		zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for POST operation on /v1/query with cache")
+		zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /v1/query with cache for")
 	} else {
-		zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for POST operation on /v1/query")
+		zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /v1/query for")
 	}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -93,9 +94,10 @@ func CreateQueryRequests(ctx context.Context, hitSize int, host, token string, w
 }
 
 // CreateReadinessRequests returns the list of requests to perform GET operation on readiness endpoint.
-func CreateReadinessRequests(ctx context.Context, hitSize int, host string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for GET operation on /readiness")
+func CreateReadinessRequests(ctx context.Context, duration time.Duration, workers int, host string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/readiness", host, "")
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for GET operation on /readiness for")
 	var requests []map[string]interface{}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -109,9 +111,10 @@ func CreateReadinessRequests(ctx context.Context, hitSize int, host string) []ma
 }
 
 // CreateLivenessRequests returns the list of requests to perform GET operation on liveness endpoint.
-func CreateLivenessRequests(ctx context.Context, hitSize int, host string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for GET operation on /liveness")
+func CreateLivenessRequests(ctx context.Context, duration time.Duration, workers int, host string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/liveness", host, "")
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for GET operation on /liveness for")
 	var requests []map[string]interface{}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -125,9 +128,10 @@ func CreateLivenessRequests(ctx context.Context, hitSize int, host string) []map
 }
 
 // CreateMetricsRequests returns the list of requests to perform GET operation on metrics endpoint.
-func CreateMetricsRequests(ctx context.Context, hitSize int, host, token string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for GET operation on /metrics")
+func CreateMetricsRequests(ctx context.Context, duration time.Duration, workers int, host, token string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/metrics", host, token)
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for GET operation on /metrics for")
 	var requests []map[string]interface{}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -141,9 +145,10 @@ func CreateMetricsRequests(ctx context.Context, hitSize int, host, token string)
 }
 
 // CreateAuthorizedRequests returns the list of requests to perform POST operation on authorized endpoint.
-func CreateAuthorizedRequests(ctx context.Context, hitSize int, host, token string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for POST operation on /authorized")
+func CreateAuthorizedRequests(ctx context.Context, duration time.Duration, workers int, host, token string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/authorized", host, token)
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /authorized for")
 	var requests []map[string]interface{}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -157,9 +162,10 @@ func CreateAuthorizedRequests(ctx context.Context, hitSize int, host, token stri
 }
 
 // CreateGetFeedbackStatusRequests returns the list of requests to perform GET operation on feedback status endpoint.
-func CreateGetFeedbackStatusRequests(ctx context.Context, hitSize int, host, token string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for GET operation on /v1/feedback/status")
+func CreateGetFeedbackStatusRequests(ctx context.Context, duration time.Duration, workers int, host, token string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/v1/feedback/status", host, token)
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for GET operation on /v1/feedback/status for")
 	var requests []map[string]interface{}
 
 	for idx := 0; idx < hitSize; idx++ {
@@ -173,9 +179,10 @@ func CreateGetFeedbackStatusRequests(ctx context.Context, hitSize int, host, tok
 }
 
 // CreateFeedbackRequests returns the list of requests to perform POST operation on feedback endpoint.
-func CreateFeedbackRequests(ctx context.Context, hitSize int, host, token string) []map[string]interface{} {
-	zlog.Info(ctx).Int("number of requests", hitSize).Msg("preparing requests for POST operation on /v1/feedback")
+func CreateFeedbackRequests(ctx context.Context, duration time.Duration, workers int, host, token string) []map[string]interface{} {
 	url, headers := getRequestCommons(ctx, "/v1/feedback", host, token)
+	hitSize := int(duration.Seconds()) * workers
+	zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /v1/feedback for")
 	var requests []map[string]interface{}
 
 	data, err := assets.ReadFile("assets/feedbacks.yaml")

--- a/attacker/types.go
+++ b/attacker/types.go
@@ -11,7 +11,8 @@ type Document struct {
 	RequestTimeout int            `json:"requestTimeout"`
 	MetricName     string         `json:"metricName"`
 	Hostname       string         `json:"hostname"`
-	Rps            int            `json:"rps"`
+	Duration       string         `json:"duration"`
+	Workers        int            `json:"workers"`
 	AttackTime     time.Duration  `json:"attackTime"`
 	WaitTime       time.Duration  `json:"waitTime"`
 	Throughput     float64        `json:"throughput"`

--- a/cmd/ols-load-generator/types.go
+++ b/cmd/ols-load-generator/types.go
@@ -1,14 +1,18 @@
 package main
 
+import (
+	"time"
+)
+
 // Type to store the test config.
 type TestConfig struct {
-	Rps        int      `json:"rps"`
-	Host       string   `json:"host"`
-	HitSize    int      `json:"hitsize"`
-	AuthToken  string   `json:"-"`
-	Uuid       string   `json:"uuid"`
-	ESHost     string   `json:"eshost"`
-	ESIndex    string   `json:"esindex"`
-	MetricStep int      `json:"metricstep"`
-	Profiles   []string `json:"profiles"`
+	Host       string        `json:"host"`
+	Duration   time.Duration `json:"duration"`
+	Workers    int           `json:"workers"`
+	AuthToken  string        `json:"-"`
+	Uuid       string        `json:"uuid"`
+	ESHost     string        `json:"eshost"`
+	ESIndex    string        `json:"esindex"`
+	MetricStep int           `json:"metricstep"`
+	Profiles   []string      `json:"profiles"`
 }

--- a/config/ols-load-generator.yaml
+++ b/config/ols-load-generator.yaml
@@ -44,10 +44,10 @@ spec:
             value: <ols-test-uuid>
           - name: OLS_TEST_AUTH_TOKEN
             value: <ols-auth-token>
-          - name: OLS_TEST_HIT_SIZE
-            value: <hit-size>
-          - name: OLS_TEST_RPS
-            value: <requests-per-second>
+          - name: OLS_TEST_DURATION
+            value: <your-test-duration>
+          - name: OLS_TEST_WORKERS
+            value: <parallel-test-workers>
           - name: OLS_TEST_METRIC_STEP
             value: <your-step-size>
           - name: OLS_TEST_PROFILES


### PR DESCRIPTION
### Description
Code changes for vegeta revamp based on the revised [test plan](https://docs.google.com/document/d/11r-6vPT-Z9nA8mMe6fa4US3OgAEUdzEuVAuY5v-wW1w/edit#heading=h.66y4kqbj468a)

Closes: https://issues.redhat.com/browse/OLS-963?filter=-1

### Testing
Tested by running on an openshift cluster. Verified the functionality from the [output logs](https://gist.github.com/vishnuchalla/2d18674e44ba07bfa8fb3f177a5cb62a)