### PR TITLE
Adding additional metrics and pod affinity rules

### DIFF
--- a/attacker/assets/profiles/metrics-report.yaml
+++ b/attacker/assets/profiles/metrics-report.yaml
@@ -9,6 +9,46 @@
   metricName: max-cpu-lightspeed
   instant: true
 
+- query: max(max_over_time(rate(ols_llm_validation_errors_total[2m])[{{.elapsed}}:])) by (pod, container, namespace)
+  metricName: max-llm-validation-errors
+  instant: true
+
+- query: avg(avg_over_time(rate(ols_llm_validation_errors_total[2m])[{{.elapsed}}:])) by (pod, container, namespace)
+  metricName: avg-llm-validation-errors
+  instant: true
+
+- query: max(max_over_time(rate(ols_llm_token_sent_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: max-llm-token-sent
+  instant: true
+
+- query: avg(avg_over_time(rate(ols_llm_token_sent_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: avg-llm-token-sent
+  instant: true
+
+- query: max(max_over_time(rate(ols_llm_token_received_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: max-llm-token-received
+  instant: true
+
+- query: avg(avg_over_time(rate(ols_llm_token_received_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: avg-llm-token-received
+  instant: true
+
+- query: max(max_over_time(rate(ols_llm_calls_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: max-llm-calls-total
+  instant: true
+
+- query: avg(avg_over_time(rate(ols_llm_calls_total[2m])[{{.elapsed}}:])) by (pod, container, namespace, provider, model)
+  metricName: avg-llm-calls-total
+  instant: true
+
+- query: max(max_over_time(rate(ols_llm_calls_failures_total[2m])[{{.elapsed}}:])) by (pod, container, namespace)
+  metricName: max-llm-call-failures
+  instant: true
+
+- query: avg(avg_over_time(rate(ols_llm_calls_failures_total[2m])[{{.elapsed}}:])) by (pod, container, namespace)
+  metricName: avg-llm-call-failures
+  instant: true
+
 - query: avg(avg_over_time(container_memory_rss{name!="", namespace="openshift-lightspeed", container!="POD"}[{{.elapsed}}:])) by (container)
   metricName: avg-memory-lightspeed
   instant: true

--- a/attacker/assets/profiles/metrics-timeseries.yaml
+++ b/attacker/assets/profiles/metrics-timeseries.yaml
@@ -7,6 +7,21 @@
 - query: sum(container_memory_rss{name!="",container!~"POD|",namespace=~"openshift-lightspeed"}) by (container, pod, namespace, node)
   metricName: containerMemory
 
+- query: sum(rate(ols_llm_validation_errors_total[2m])) by (pod, container, namespace)
+  metricName: llmValidationErrors
+
+- query: sum(rate(ols_llm_token_sent_total[2m])) by (pod, container, namespace, provider, model)
+  metricName: llmTokenSent
+
+- query: sum(rate(ols_llm_token_received_total[2m])) by (pod, container, namespace, provider, model)
+  metricName: llmTokenReceived
+
+- query: sum(rate(ols_llm_calls_total[2m])) by (pod, container, namespace, provider, model)
+  metricName: llmCallsTotal
+
+- query: sum(rate(ols_llm_calls_failures_total[2m])) by (pod, container, namespace)
+  metricName: llmCallFailures
+
 - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-lightspeed"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
   metricName: containerCPU-AggregatedWorkers
 

--- a/config/ols-load-generator.yaml
+++ b/config/ols-load-generator.yaml
@@ -32,6 +32,37 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: In
+                values:
+                - ""
+        podAffinity: {}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - application-server
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - lightspeed-service-api
+                  - key: app.kubernetes.io/part-of
+                    operator: In
+                    values:
+                      - openshift-lightspeed
+                  - key: app.kubernetes.io/managed-by
+                    operator: In
+                    values:
+                      - lightspeed-operator
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: ols-load-generatoring
         image: quay.io/vchalla/ols-load-generator:amd64


### PR DESCRIPTION
### Description
Code changes add additional metrics and pod affinity rules based on the revised [test plan](https://docs.google.com/document/d/11r-6vPT-Z9nA8mMe6fa4US3OgAEUdzEuVAuY5v-wW1w/edit#heading=h.66y4kqbj468a)

Closes: https://issues.redhat.com/browse/OLS-966

### Testing
Tested by running on an openshift cluster. Verified the functionality from the [output logs](https://gist.github.com/vishnuchalla/0f592dd2654bfa5c2a386b6d313136b7).
Grafana [dashboard link ](https://grafana.rdu2.scalelab.redhat.com:3000/d/edrn4yn2nu134d/ols-load-test-results?orgId=1&var-Datasource=ddrn4jjyn41kwd&var-duration=1m0s&var-workers=25&var-uuid=4f428c47-65ab-4601-80e5-e81653f6298b&var-targets=post_query&from=1724868023783&to=1724869823783) with new metrics.