### PR TITLE
Adding streaming api and queryonly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ oc create secret generic kubeconfig-secret --from-file=kubeconfig=<YOUR-KUBECONF
 * `OLS_TEST_PROFILES` - List of metric profiles that contain queries to be executed on prometheus.
 * `OLS_TEST_ES_HOST`(Optional) - Elastic search host url. If not specified metrics will be indexed locally.
 * `OLS_TEST_ES_INDEX`(Optional) - Elastic search index name to store the data. If not specified metrics will be indexed locally.
+* `OLS_TEST_QUERY_ONLY`(Optional) - Flag to enable load tests only on `/v1/query` and `/v1/streaming_query` endpoints.
 
 #### **Example Usage**
 ```
@@ -80,13 +81,14 @@ DESCRIPTION:
 OPTIONS:
    --host value        --host localhost:6060 (default: "http://localhost:6060") [$OLS_TEST_HOST]
    --authtoken value   --authtoken authtoken [$OLS_TEST_AUTH_TOKEN]
-   --uuid value        --uuid f519d9b2-aa62-44ab-9ce8-4156b712f6d2 (default: "08fd0205-d2d8-4954-b83e-86226dd4e2ac") [$OLS_TEST_UUID]
+   --uuid value        --uuid f519d9b2-aa62-44ab-9ce8-4156b712f6d2 (default: "76d8f64d-2bf3-49ac-82c3-22011ddc2284") [$OLS_TEST_UUID]
    --duration value    --duration 1m (default: 1m0s) [$OLS_TEST_DURATION]
    --workers value     --workers 10 (default: 10) [$OLS_TEST_WORKERS]
    --eshost value      --eshost eshosturl [$OLS_TEST_ES_HOST]
    --esindex value     --esindex esindex [$OLS_TEST_ES_INDEX]
    --metricstep value  --metricstep 30 (default: 30) [$OLS_TEST_METRIC_STEP]
    --profiles value    --profiles metrics.yaml,metrics-report.yaml (default: "attacker/assets/profiles/metrics-report.yaml,attacker/assets/profiles/metrics-timeseries.yaml") [$OLS_TEST_PROFILES]
+   --queryonly         --query (default: false) [$OLS_TEST_QUERY_ONLY]
    --help, -h          show help
 ```
 #### Example Usage
@@ -114,6 +116,7 @@ OPTIONS:
    --start value       --start 1720410990 (default: 1720482385) [$OLS_TEST_START]
    --end value         --end 1720470990 (default: 1720485985) [$OLS_TEST_END]
    --profiles value    --profiles metrics.yaml,metrics-report.yaml (default: "attacker/assets/profiles/metrics-report.yaml,attacker/assets/profiles/metrics-timeseries.yaml") [$OLS_TEST_PROFILES]
+   --queryonly         --query (default: false) [$OLS_TEST_QUERY_ONLY]
    --help, -h          show help
 ```
 #### Example Usage

--- a/attacker/apis.go
+++ b/attacker/apis.go
@@ -48,8 +48,15 @@ func getRequestCommons(ctx context.Context, endpoint, host, token string) (strin
 }
 
 // CreateQueryRequests returns the list of requests to perform POST operation on query endpoint.
-func CreateQueryRequests(ctx context.Context, duration time.Duration, workers int, host, token string, withCache bool) []map[string]interface{} {
-	url, headers := getRequestCommons(ctx, "/v1/query", host, token)
+func CreateQueryRequests(ctx context.Context, duration time.Duration, workers int, host, token string, withCache bool, streamResponse bool) []map[string]interface{} {
+	var subPath string
+	conversationIdPrefix := "00000000-0000-0000-0000-"
+	if streamResponse {
+		subPath = "streaming_query"
+	} else {
+		subPath = "query"
+	}
+	url, headers := getRequestCommons(ctx, fmt.Sprintf("/v1/%s", subPath), host, token)
 	hitSize := int(duration.Seconds()) * workers
 	var requests []map[string]interface{}
 
@@ -71,14 +78,20 @@ func CreateQueryRequests(ctx context.Context, duration time.Duration, workers in
 
 	body := make(map[string]string)
 	if withCache {
-		body["conversation_id"] = "00000000-0000-0000-0000-000000000000"
 		zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /v1/query with cache for")
 	} else {
 		zlog.Info(ctx).Str("duration", duration.String()).Msg("preparing requests for POST operation on /v1/query for")
 	}
 
 	for idx := 0; idx < hitSize; idx++ {
-		body["query"] = questionList.Questions[idx%len(questionList.Questions)]
+		modValue := idx % len(questionList.Questions)
+		body["query"] = questionList.Questions[modValue]
+		if withCache {
+			body["conversation_id"] = conversationIdPrefix + fmt.Sprintf("%012d", modValue)
+			if streamResponse {
+				body["conversation_id"] = conversationIdPrefix + fmt.Sprintf("%011d", modValue) + "0"
+			}
+		}
 		bodyBytes, err := json.Marshal(body)
 		if err != nil {
 			fmt.Errorf("Error marshaling body: %v", err)

--- a/attacker/attacker.go
+++ b/attacker/attacker.go
@@ -81,6 +81,7 @@ func indexVegetaResults(ctx context.Context, metrics vegeta.Metrics, testName st
 		return fmt.Errorf("Failure while creating an indexer: %w", err)
 	}
 	workers, _ := strconv.Atoi(attackMap["Workers"])
+	queryOnly, _ := strconv.ParseBool(attackMap["QueryOnly"])
 	hostname, _ := os.Hostname()
 	resp, err := (*indexer).Index([]interface{}{Document{
 		Workload:       "ols-load-generator",
@@ -106,6 +107,7 @@ func indexVegetaResults(ctx context.Context, metrics vegeta.Metrics, testName st
 		BytesIn:        metrics.BytesIn.Mean,
 		BytesOut:       metrics.BytesOut.Mean,
 		Uuid:           attackMap["Uuid"],
+		QueryOnly:      queryOnly,
 	}}, indexers.IndexingOpts{
 		MetricName: testName,
 	})

--- a/attacker/types.go
+++ b/attacker/types.go
@@ -29,4 +29,5 @@ type Document struct {
 	BytesIn        float64        `json:"bytesIn"`
 	BytesOut       float64        `json:"bytesOut"`
 	Uuid           string         `json:"uuid"`
+	QueryOnly      bool           `json:"queryonly"`
 }

--- a/cmd/ols-load-generator/attack.go
+++ b/cmd/ols-load-generator/attack.go
@@ -74,6 +74,12 @@ var AttackCmd = &cli.Command{
 			Value:   "attacker/assets/profiles/metrics-report.yaml,attacker/assets/profiles/metrics-timeseries.yaml",
 			EnvVars: []string{"OLS_TEST_PROFILES"},
 		},
+		&cli.BoolFlag{
+			Name:    "queryonly",
+			Usage:   "--query",
+			Value:   false,
+			EnvVars: []string{"OLS_TEST_QUERY_ONLY"},
+		},
 	},
 }
 
@@ -89,6 +95,7 @@ func attackConfig(c *cli.Context) *TestConfig {
 		ESHost:     c.String("eshost"),
 		ESIndex:    c.String("esindex"),
 		MetricStep: c.Int("metricstep"),
+		QueryOnly:  c.Bool("queryonly"),
 		Profiles:   strings.Split(strings.TrimSpace(profilesArg), ","),
 	}
 }
@@ -123,60 +130,75 @@ func orchestrateWorkload(ctx context.Context, conf *TestConfig) error {
 	var requests []map[string]interface{}
 	var err error
 	attackMap := map[string]string{
-		"Uuid":     conf.Uuid,
-		"Workers":  strconv.Itoa(conf.Workers),
-		"Duration": conf.Duration.String(),
-		"ESHost":   conf.ESHost,
-		"ESIndex":  conf.ESIndex,
-		"Host":     conf.Host,
+		"Uuid":      conf.Uuid,
+		"Workers":   strconv.Itoa(conf.Workers),
+		"Duration":  conf.Duration.String(),
+		"ESHost":    conf.ESHost,
+		"ESIndex":   conf.ESIndex,
+		"Host":      conf.Host,
+		"QueryOnly": strconv.FormatBool(conf.QueryOnly),
 	}
 
-	requests = attacker.CreateReadinessRequests(ctx, conf.Duration, conf.Workers, conf.Host)
-	err = attacker.RunVegeta(ctx, requests, "get_readiness", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running GET operation on /readiness: %w", err)
+	if !conf.QueryOnly {
+		requests = attacker.CreateReadinessRequests(ctx, conf.Duration, conf.Workers, conf.Host)
+		err = attacker.RunVegeta(ctx, requests, "get_readiness", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running GET operation on /readiness: %w", err)
+		}
+
+		requests = attacker.CreateLivenessRequests(ctx, conf.Duration, conf.Workers, conf.Host)
+		err = attacker.RunVegeta(ctx, requests, "get_liveness", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running GET operation on /liveness: %w", err)
+		}
+
+		requests = attacker.CreateAuthorizedRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
+		err = attacker.RunVegeta(ctx, requests, "post_authorized", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running POST operation on /authorized: %w", err)
+		}
+
+		requests = attacker.CreateMetricsRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
+		err = attacker.RunVegeta(ctx, requests, "get_metrics", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running GET operation on /metrics: %w", err)
+		}
+
+		requests = attacker.CreateGetFeedbackStatusRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
+		err = attacker.RunVegeta(ctx, requests, "get_feedback_status", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running GET operation on /v1/feedback/status: %w", err)
+		}
+
+		requests = attacker.CreateFeedbackRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
+		err = attacker.RunVegeta(ctx, requests, "post_feedback", attackMap)
+		if err != nil {
+			return fmt.Errorf("Error while running POST operation on /v1/feedback: %w", err)
+		}
 	}
 
-	requests = attacker.CreateLivenessRequests(ctx, conf.Duration, conf.Workers, conf.Host)
-	err = attacker.RunVegeta(ctx, requests, "get_liveness", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running GET operation on /liveness: %w", err)
-	}
-
-	requests = attacker.CreateAuthorizedRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
-	err = attacker.RunVegeta(ctx, requests, "post_authorized", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running POST operation on /authorized: %w", err)
-	}
-
-	requests = attacker.CreateMetricsRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
-	err = attacker.RunVegeta(ctx, requests, "get_metrics", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running GET operation on /metrics: %w", err)
-	}
-
-	requests = attacker.CreateGetFeedbackStatusRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
-	err = attacker.RunVegeta(ctx, requests, "get_feedback_status", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running GET operation on /v1/feedback/status: %w", err)
-	}
-
-	requests = attacker.CreateFeedbackRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken)
-	err = attacker.RunVegeta(ctx, requests, "post_feedback", attackMap)
-	if err != nil {
-		return fmt.Errorf("Error while running POST operation on /v1/feedback: %w", err)
-	}
-
-	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, false)
+	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, false, false)
 	err = attacker.RunVegeta(ctx, requests, "post_query", attackMap)
 	if err != nil {
 		return fmt.Errorf("Error while running POST operation on /v1/query: %w", err)
 	}
 
-	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, true)
+	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, false, true)
+	err = attacker.RunVegeta(ctx, requests, "post_streaming_query", attackMap)
+	if err != nil {
+		return fmt.Errorf("Error while running POST operation on /v1/streaming_query: %w", err)
+	}
+
+	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, true, false)
 	err = attacker.RunVegeta(ctx, requests, "post_query_with_cache", attackMap)
 	if err != nil {
 		return fmt.Errorf("Error while running POST operation on /v1/query with cache: %w", err)
+	}
+
+	requests = attacker.CreateQueryRequests(ctx, conf.Duration, conf.Workers, conf.Host, conf.AuthToken, true, true)
+	err = attacker.RunVegeta(ctx, requests, "post_streaming_query_with_cache", attackMap)
+	if err != nil {
+		return fmt.Errorf("Error while running POST operation on /v1/streaming_query with cache: %w", err)
 	}
 
 	zlog.Info(ctx).Str("Uuid", conf.Uuid).Msg("👋 Exiting ols-load-generator")

--- a/cmd/ols-load-generator/types.go
+++ b/cmd/ols-load-generator/types.go
@@ -15,4 +15,5 @@ type TestConfig struct {
 	ESIndex    string        `json:"esindex"`
 	MetricStep int           `json:"metricstep"`
 	Profiles   []string      `json:"profiles"`
+	QueryOnly  bool          `json:"queryonly"`
 }

--- a/config/ols-load-generator.yaml
+++ b/config/ols-load-generator.yaml
@@ -64,7 +64,7 @@ spec:
                       - lightspeed-operator
               topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: ols-load-generatoring
+      - name: ols-load-generator
         image: quay.io/vchalla/ols-load-generator:amd64
         securityContext:
           privileged: true
@@ -87,6 +87,8 @@ spec:
             value: <es-url>
           - name: OLS_TEST_ES_INDEX
             value: <es-index>
+          - name: OLS_TEST_QUERY_ONLY
+            value: <boolean-flag>
         volumeMounts:
           - name: kubeconfig-volume
             mountPath: /etc/kubeconfig


### PR DESCRIPTION
### Description
* Adding streaming API (.i.e. both with and without cache cases) to the load tests.
* Added a flag to run load only on `/v1/query` and `/v1/streaming_query` endpoints as we do not need load tests on all the api endpoints all the time.
* Also modified cache logic enabling cache for multiple sessions.


### Testing
Tested and verified in local: https://gist.github.com/vishnuchalla/2fe9ab155352b382af09e9fb71a51d75 
Grafana [Link](https://grafana.rdu2.scalelab.redhat.com:3000/d/edrn4yn2nu134d/ols-load-test-results?orgId=1&var-Datasource=adxoeyovkncowb&var-duration=All&var-workers=All&var-uuid=597af789-eedc-4d5c-9f38-027abdd7640a&var-targets=post_streaming_query_with_cache&from=1738673046930&to=1738677118655). Creds (`viewer/viewer`)