### PR TITLE
add missing gpgme package for Prow failure

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -15,8 +15,12 @@ RUN dnf install -y \
         podman \
         python3-pip \
         gcc \
-        go && \
+        go \
+        pkgconf-pkg-config \
+        gpgme-devel && \
     dnf clean all
+
+RUN pkg-config --modversion gpgme
 
 # Set GO environment variables (to ensure it's set correctly)
 ENV GOPATH=/root/go


### PR DESCRIPTION
Issue and finding: found a pattern in recent prow jobs failures in #ols-perf-scale-ci-results Slack channel.

Example/Evidence:
On Mar 3rd, [periodic-ci-openshift-ols-load-generator-main-ols-load-test-50workers](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-ols-load-generator-main-ols-load-test-50workers/2028802935177089024) job's build-log.txt shows the lack of gpgme package, which leads to "make deploy" failure.
<img width="1916" height="138" alt="image" src="https://github.com/user-attachments/assets/40c3cd08-5e53-4c45-82d0-edfca0fc2490" />

Similarly, 
[100 worker's job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-ols-load-generator-main-ols-load-test-100workers/2028539933437726720) is failing on Mar 2nd for the same reason:
<img width="1920" height="150" alt="image" src="https://github.com/user-attachments/assets/c63ff687-0299-4f44-a664-ea0025ed3119" />

From [here](https://github.com/openshift/release/blob/main/ci-operator/step-registry/openshift/ols-load-generator/tests/openshift-ols-load-generator-tests-ref.yaml), we can verify the image used is ols-load-generator-ci. and this image is built from prow/Dockerfile according to [here](https://github.com/openshift/release/blob/main/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main.yaml). Therefore, add missing gpgme package to the Dockerfile would likely be the fix.

Testing:
I built the image locally and verified the missing package is presented in the image:
<img width="700" height="86" alt="image" src="https://github.com/user-attachments/assets/99c23ca2-575f-4408-ba42-e4299112b41f" />

